### PR TITLE
Use updated connect api.

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,9 @@ module.exports = function (sails) {
         //
         // We save a reference to this Mongoose db connection, and listen for the first error emitted from it.
         // (any subsequent error events emitted that are emitted will crash the server!)
-        var dbConnection = sails.mongoose.connect(sails.config.mongoose.uri, sails.config.mongoose.connectionOpts).connection;
+        var opts = sails.config.mongoose.connectionOpts || {};
+        opts.useMongoClient = true;
+        var dbConnection = sails.mongoose.connect(sails.config.mongoose.uri, opts);
         dbConnection.once('error', function (err){
 
           // Handle weird (and very unlikely) case where Mongoose emits an error event without sending an Error instance as the event data.


### PR DESCRIPTION
Updated connection handling to use updated api.

Fixed deprecation warning:

```
DeprecationWarning: `open()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/connections.html#use-mongo-client
```